### PR TITLE
Fix bug where resetting `ChartProvider`'s `seriesIds` could overflow the stack.

### DIFF
--- a/API.md
+++ b/API.md
@@ -22,7 +22,7 @@ For specifics on the exact types of these components/functions/values, please ch
 #### Props
 
 - `seriesIds`: a list of all the series that are present in this chart. IDs are arbitrary and must be unique within a single `ChartProvider`. Series IDs not present here will be silently ignored.
-- `loadData`: a stateless function to load the appropriate data for all series. Called whenever `ChartProvider` needs new data. This is where you should do caching or other loading optimizations.
+- `loadData`: a stateless function to load the appropriate data for all series. Called whenever `ChartProvider` needs new data. This is where you should do caching or other loading optimizations. Avoid using an inline definition, as that creates a new function object, and data must be reloaded whenever `loadData` changes.
 - `className?`: space-separated DOM class names to be merged with the default class names.
 - `pixelRatio?`: the desired pixel density of this chart. See [`window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio). Performance may suffer with higher values. This value is not transparently applied and must be explicitly respected by any contained `Layer`s (the built-in ones all do). If specified here, you do not need to specify this value on any contained `Stack`s.
 - `chartId?`: an arbitrary, globally-unique ID for the state of this chart that maintains a reference across mount/unmount cycles.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ This likely happens because you've forgotten to include react-layered-chart's st
 
 Specify a globally-unique `chartId` string prop to `ChartProvider` so on next mount it can retrieve its old state. See the [caveat on (un)mounting](#tracking-transient-state-across-unmount-cycles) for more details.
 
+### Loads are consistently and frequently triggered even when nothing is changing
+
+This can happen if you provide a functionally-equal but reference-unequal value for `ChartProvider`'s `loadData`. Changing the `loadData` reference triggers a load, which will likely return value-equal but reference-unequal results if nothing else has changed. If you take the direct or indirect result of this load (such as through an "on change" listener) and cause a rerender (such as by setting state) and you end up passing a new instance of a `loadData` function, you will be caught in a very slow infinite loop.
+
 ## API Reference
 
 See [API Reference](API.md).

--- a/src/connected/ChartProvider.tsx
+++ b/src/connected/ChartProvider.tsx
@@ -74,6 +74,7 @@ export default class ChartProvider extends React.Component<Props, {}> {
 
   componentWillReceiveProps(nextProps: Props) {
     if (nextProps.chartId !== this.props.chartId) {
+      this._tryUnsubscribe();
       this._store = storeFactory(this.props.chartId);
       this._onStoreChange(nextProps);
     } else {
@@ -85,8 +86,14 @@ export default class ChartProvider extends React.Component<Props, {}> {
     this._tryUnsubscribe();
   }
 
+  private _tryUnsubscribe() {
+    if (this._unsubscribeCallback) {
+      this._unsubscribeCallback();
+    }
+    this._lastState = null;
+  }
+
   private _onStoreChange(props: Props) {
-    this._tryUnsubscribe();
     this._lastState = this._store.getState();
 
     this._store.dispatch(setSeriesIds(props.seriesIds));
@@ -111,13 +118,6 @@ export default class ChartProvider extends React.Component<Props, {}> {
 
     this._maybeFireAllCallbacks();
     this._unsubscribeCallback = this._store.subscribe(this._maybeFireAllCallbacks.bind(this));
-  }
-
-  private _tryUnsubscribe() {
-    if (this._unsubscribeCallback) {
-      this._unsubscribeCallback();
-    }
-    this._lastState = null;
   }
 
   private _maybeFireAllCallbacks() {

--- a/src/connected/flux/reducer.ts
+++ b/src/connected/flux/reducer.ts
@@ -38,16 +38,20 @@ export default function(state: ChartState, action: Action<any>): ChartState {
 
   switch (action.type) {
     case ActionType.SET_SERIES_IDS: {
-      const seriesIds = _.clone(action.payload);
-      return update(state, {
-        seriesIds: { $set: seriesIds },
-        dataBySeriesId: { $set: objectWithKeysFromObject(state.dataBySeriesId, seriesIds, []) },
-        loadVersionBySeriesId: { $set: objectWithKeysFromObject(state.loadVersionBySeriesId, seriesIds, null) },
-        errorBySeriesId: { $set: objectWithKeysFromObject(state.errorBySeriesId, seriesIds, null) },
-        uiState: {
-          yDomainBySeriesId: { $set: objectWithKeysFromObject(state.uiState.yDomainBySeriesId, seriesIds, DEFAULT_Y_DOMAIN) }
-        }
-      });
+      if (_.isEqual(_.sortBy(action.payload), _.sortBy(state.seriesIds))) {
+        return state;
+      } else {
+        const seriesIds = _.clone(action.payload);
+        return update(state, {
+          seriesIds: { $set: seriesIds },
+          dataBySeriesId: { $set: objectWithKeysFromObject(state.dataBySeriesId, seriesIds, []) },
+          loadVersionBySeriesId: { $set: objectWithKeysFromObject(state.loadVersionBySeriesId, seriesIds, null) },
+          errorBySeriesId: { $set: objectWithKeysFromObject(state.errorBySeriesId, seriesIds, null) },
+          uiState: {
+            yDomainBySeriesId: { $set: objectWithKeysFromObject(state.uiState.yDomainBySeriesId, seriesIds, DEFAULT_Y_DOMAIN) }
+          }
+        });
+      }
     }
 
     case ActionType.DATA_REQUESTED:

--- a/test/reducer-test.ts
+++ b/test/reducer-test.ts
@@ -150,6 +150,13 @@ describe('reducer', () => {
     });
   });
 
+  it('should do nothing if the same set of series IDs is provided that already exists', () => {
+    const beforeState = reducer(state, action(ActionType.SET_SERIES_IDS, ALL_SERIES));
+    const afterState = reducer(beforeState, action(ActionType.SET_SERIES_IDS, _.clone(ALL_SERIES).reverse()));
+
+    beforeState.should.be.exactly(afterState);
+  });
+
   it('should remove outdated keys from fields that are keyed by series ID when resetting series ID', () => {
     const ONLY_SERIES_A = [ SERIES_A ];
     state = serial(state,


### PR DESCRIPTION
Add tests for the reducer to catch this case in the future.

The bug would happen if you did three things;

- Set the `seriesIds` prop to an inline array literal, thereby bypassing reference-equality checks.
- Provided any of the callback methods, such as `onYDomainsChange`.
- In the callback method, you did something that caused a rerender, such as setting state.

The bug happens like so:

1. On initial render, initialize the store and kick off any callbacks.
2. Callback sets state or otherwise causes a rerender.
3. render passes array literal to `ChartProvider`, which dispatches `setSeriesIds`.
4. Reducer recomputes a bunch of state for the new IDs, but the only thing that changes
   is the outermost object.
5. Callbacks fire because the state changed.
6. Go to 2.

The simple solution is to ignore any request to change `seriesIds` in a deeply-equal way.

Additionally, a related by marginally less severe issue caused by reference-unequal
values for `loadData` can only realistically be avoided by warning people that they
MUST provide reference-equal values for it if they don't intend to change it. The docs
have been updated to mention this.

This bug is truly caused by a deeper, two-way-binding issue. `ChartProvider` is mediating
reads and writes in two directions using two different patterns, and is rather
error-prone. I tried to repair the underlying issue, but it's nontrivial. This solution
seems reasonable, because setting `seriesIds` is currently the only way to actually get
into this loop. Making the loop impossible in the first place is tricky. The reason that
this is the only setting that can cause the loop is as follows:

- This can only be caused by props that interact with the store, either be reading from
  it (in the case of "on change" functions) or writing to it (in the case of "controlled
  props").
- Six props can be pushed to the store, and six values can be read from the store into
  a callback.
- Of the six values read from the store, four are NON-overridden UI state, and the other
  two are load state/results.
- Of the six props that are written to the store four are overridden UI state, one
  triggers a deferred load (`loadData`) and and the last is `seriesIds`.
- The four reads and four writes that are UI-related don't interact with each other, since
  they deal with different underlying settings (override versus not).
- The two reads and one write that are loading-related can indeed cause a loop, but
  because it's necessarily debounced/deferred and because we can't actually examine the
  culprit (i.e. `loadData`) for deep equality, the best we can do is documentation.
- `seriesIds` is the last remaining option: before this change, a deeply-equal value
  used to cause a rewrite of the outermost objects for (among other things) the NON-
  overridden UI state. It wouldn't change the object's values in this case, however.
- That overwrite would trigger the callbacks (unlike the UI-related props) and those
  callbacks had the potential to synchronously loop (unlike the loading-related props).

Therefore, the only combination of props that could cause this issue are `seriesIds` and
any of the UI callbacks. `loadData` and friends can cause a slow-motion infinite loop
that is deferred enough to prevent crushing disaster like this stack overflow, but still
sucks (and is therefore documented).

This fix is unfortunately a bit fragile in that it doesn't fix the underlying issue,
and any new props or interactions between these props might reintroduce it. Hopefully
this commit message and the slightly unusual deep-equality check in the reducer are
warning enough.