### PR TITLE
Fix autoresizing pixelratio bug

### DIFF
--- a/API.md
+++ b/API.md
@@ -148,7 +148,6 @@ A component that wraps and exposes a `<canvas>` that (via polling) matches the s
 
 - `onSizeChange()`: a function called with no arguments when the size changes, usually, some kind of render method.
 - `pixelRatio?`: the pixel ratio this `<canvas>` should render at. See [`Stack`](#stack) for more on this value.
-- `className?`: space-separated DOM class names to be merged with the default class names.
 
 #### Instance Methods
 

--- a/API.md
+++ b/API.md
@@ -118,7 +118,9 @@ There is a `ConnectedYAxisLayer` that accepts the same props, except each item i
 
 <hr/>
 
-### `AutoresizingCanvasLayer`
+### ~~`AutoresizingCanvasLayer`~~
+
+**This component is deprecated. Use [`PollingResizingCanvasLayer`](#pollingresizingcanvaslayer) instead.**
 
 A component that wraps and exposes a `<canvas>` that (via polling) matches the size of its containing `Stack`. This class does no rendering of its own, but provides a well-behaved blank canvas for a parent component to draw on. All built-in data-rendering layers are based on this component in combination with the `NonReactRender` decorator.
 
@@ -135,6 +137,24 @@ A component that wraps and exposes a `<canvas>` that (via polling) matches the s
 #### Static Methods
 
 - `resetCanvas(canvasLayer, pixelRatio?)`: clears and resizes the underlying `<canvas>` for the given `canvasLayer` in preparation for a rendering frame. Additionally, it translates the canvas by half a pixel to get crisper rendering behavior. Returns `{ width, height, context }`.
+
+<hr/>
+
+### `PollingResizingCanvasLayer`
+
+A component that wraps and exposes a `<canvas>` that (via polling) matches the size of its containing `Stack`. This class does no rendering of its own, but provides a well-behaved blank canvas for a parent component to draw on. All built-in data-rendering layers are based on this component in combination with the `NonReactRender` decorator.
+
+#### Props
+
+- `onSizeChange()`: a function called with no arguments when the size changes, usually, some kind of render method.
+- `pixelRatio?`: the pixel ratio this `<canvas>` should render at. See [`Stack`](#stack) for more on this value.
+- `className?`: space-separated DOM class names to be merged with the default class names.
+
+#### Instance Methods
+
+- `getCanvasElement()`: returns the `<canvas>` element for this layer.
+- `getDimensions()`: returns the true `{ width, height }` of this layer.
+- `resetCanvas()`: clears and resizes the underlying `<canvas>` in preparation for a rendering frame. Additionally, it translates the canvas by half a pixel to get crisper rendering behavior. Returns `{ width, height, context }`.
 
 <hr/>
 

--- a/src/connected/flux/dataActions.ts
+++ b/src/connected/flux/dataActions.ts
@@ -5,7 +5,7 @@ import ActionType, { Action } from '../model/ActionType';
 import { ChartState} from '../model/state';
 import { SeriesId, TBySeriesId, DataLoader, LoadedSeriesData } from '../interfaces';
 import { setYDomain } from './uiActions';
-import { selectXDomain, selectYDomains } from '../model/selectors';
+import { selectXDomain } from '../model/selectors';
 
 function _makeKeyedDataBatcher<T>(onBatch: (batchData: TBySeriesId<T>) => void): (partialData: TBySeriesId<T>) => void {
   let keyedBatchAccumulator: TBySeriesId<T> = {};
@@ -34,7 +34,7 @@ export function _performDataLoad() {
     const loadPromiseBySeriesId = dataLoader(
       seriesIdsToLoad,
       selectXDomain(preLoadChartState),
-      selectYDomains(preLoadChartState),
+      preLoadChartState.uiState.yDomainBySeriesId,
       preLoadChartState.physicalChartWidth,
       preLoadChartState.dataBySeriesId
     );

--- a/src/connected/flux/dataActions.ts
+++ b/src/connected/flux/dataActions.ts
@@ -1,7 +1,7 @@
 import * as _ from 'lodash';
 
-import { Interval, SeriesData } from '../../core';
-import ActionType, { Action } from '../model/ActionType';
+import { Interval } from '../../core';
+import ActionType from '../model/ActionType';
 import { ChartState} from '../model/state';
 import { SeriesId, TBySeriesId, DataLoader, LoadedSeriesData } from '../interfaces';
 import { setYDomain } from './uiActions';

--- a/src/core/layers/AutoresizingCanvasLayer.tsx
+++ b/src/core/layers/AutoresizingCanvasLayer.tsx
@@ -16,7 +16,7 @@ export interface State {
 
 @PureRender
 @PixelRatioContext
-export default class AutoresizingCanvasLayer extends React.Component<Props, State> {
+export default class PollingResizingCanvasLayer extends React.Component<Props, State> {
   context: Context;
 
   private __setSizeInterval: number;
@@ -26,7 +26,7 @@ export default class AutoresizingCanvasLayer extends React.Component<Props, Stat
     className: React.PropTypes.string
   } as React.ValidationMap<Props>;
 
-  static resetCanvas(canvasLayer: AutoresizingCanvasLayer, pixelRatio: number = 1) {
+  static resetCanvas(canvasLayer: PollingResizingCanvasLayer, pixelRatio: number = 1) {
     const canvas = canvasLayer.getCanvasElement();
     const { width, height } = canvasLayer.getDimensions();
     const context = canvas.getContext('2d');

--- a/src/core/layers/BarLayer.tsx
+++ b/src/core/layers/BarLayer.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import * as PureRender from 'pure-render-decorator';
 import * as d3Scale from 'd3-scale';
-import * as _ from 'lodash';
 
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import { getIndexBoundsForSpanData } from '../renderUtils';
 import { wrapWithAnimatedYDomain } from '../componentUtils';
 import propTypes from '../propTypes';
@@ -37,14 +36,15 @@ class BarLayer extends React.Component<Props, void> {
   } as any as Props;
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     const { firstIndex, lastIndex } = getIndexBoundsForSpanData(this.props.data, this.props.xDomain, 'minXValue', 'maxXValue');
     if (firstIndex === lastIndex) {

--- a/src/core/layers/BrushLayer.tsx
+++ b/src/core/layers/BrushLayer.tsx
@@ -5,7 +5,7 @@ import * as d3Scale from 'd3-scale';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import propTypes from '../propTypes';
 import { Interval, Color } from '../interfaces';
 
@@ -35,14 +35,15 @@ export default class BrushLayer extends React.Component<Props, void> {
   } as any as Props;
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     if (!this.props.selection) {
       return;

--- a/src/core/layers/BucketedLineLayer.tsx
+++ b/src/core/layers/BucketedLineLayer.tsx
@@ -5,7 +5,7 @@ import * as d3Scale from 'd3-scale';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import { getIndexBoundsForSpanData } from '../renderUtils';
 import { wrapWithAnimatedYDomain } from '../componentUtils';
 import propTypes from '../propTypes';
@@ -43,14 +43,15 @@ class BucketedLineLayer extends React.Component<Props, void> {
   };
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     // Should we draw something if there is one data point?
     if (this.props.data.length < 2) {

--- a/src/core/layers/HoverLineLayer.tsx
+++ b/src/core/layers/HoverLineLayer.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import propTypes from '../propTypes';
 import { Interval, Color } from '../interfaces';
 
@@ -33,14 +33,15 @@ export default class HoverLineLayer extends React.Component<Props, void> {
   } as any as Props;
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     if (!_.isNumber(this.props.hover)) {
       return;

--- a/src/core/layers/PointLayer.tsx
+++ b/src/core/layers/PointLayer.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import { getIndexBoundsForPointData } from '../renderUtils';
 import { wrapWithAnimatedYDomain } from '../componentUtils';
 import propTypes from '../propTypes';
@@ -46,14 +46,15 @@ class PointLayer extends React.Component<Props, void> {
   } as any as Props;
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     const { firstIndex, lastIndex } = getIndexBoundsForPointData(this.props.data, this.props.xDomain, 'xValue');
     if (firstIndex === lastIndex) {

--- a/src/core/layers/PollingResizingCanvasLayer.tsx
+++ b/src/core/layers/PollingResizingCanvasLayer.tsx
@@ -1,11 +1,9 @@
 import * as React from 'react';
 import * as PureRender from 'pure-render-decorator';
-import * as classNames from 'classnames';
 
 export interface Props {
   onSizeChange: () => void;
   pixelRatio?: number;
-  className?: string;
 }
 
 export interface State {
@@ -19,7 +17,6 @@ export default class PollingResizingCanvasLayer extends React.Component<Props, S
 
   static propTypes = {
     onSizeChange: React.PropTypes.func.isRequired,
-    className: React.PropTypes.string
   } as React.ValidationMap<Props>;
 
   static defaultProps = {
@@ -33,7 +30,7 @@ export default class PollingResizingCanvasLayer extends React.Component<Props, S
 
   render() {
     return (
-      <div className={classNames('resizing-wrapper', this.props.className)} ref='wrapper'>
+      <div className='resizing-wrapper' ref='wrapper'>
         <canvas
           className='canvas'
           ref='canvas'

--- a/src/core/layers/PollingResizingCanvasLayer.tsx
+++ b/src/core/layers/PollingResizingCanvasLayer.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import * as PureRender from 'pure-render-decorator';
+import * as classNames from 'classnames';
+
+export interface Props {
+  onSizeChange: () => void;
+  pixelRatio?: number;
+  className?: string;
+}
+
+export interface State {
+  width: number;
+  height: number;
+}
+
+@PureRender
+export default class PollingResizingCanvasLayer extends React.Component<Props, State> {
+  private __setSizeInterval: number;
+
+  static propTypes = {
+    onSizeChange: React.PropTypes.func.isRequired,
+    className: React.PropTypes.string
+  } as React.ValidationMap<Props>;
+
+  static defaultProps = {
+    pixelRatio: 1
+  } as any as Props;
+
+  state = {
+    width: 0,
+    height: 0
+  };
+
+  render() {
+    return (
+      <div className={classNames('resizing-wrapper', this.props.className)} ref='wrapper'>
+        <canvas
+          className='canvas'
+          ref='canvas'
+          width={this.state.width * this.props.pixelRatio}
+          height={this.state.height * this.props.pixelRatio}
+          style={{ width: this.state.width, height: this.state.height }}
+        />
+      </div>
+    );
+  }
+
+  getCanvasElement() {
+    return this.refs['canvas'] as HTMLCanvasElement;
+  }
+
+  getDimensions() {
+    return {
+      width: this.state.width,
+      height: this.state.height
+    };
+  }
+
+  resetCanvas() {
+    const canvas = this.getCanvasElement();
+    const { width, height } = this.state;
+    const context = canvas.getContext('2d');
+
+    context.setTransform(1, 0, 0, 1, 0, 0); // Same as resetTransform, but actually part of the spec.
+    context.scale(this.props.pixelRatio, this.props.pixelRatio);
+    context.clearRect(0, 0, width, height);
+    // TODO: I think this might have to be multiplied by pixelRatio to properly un-blur the canvas.
+    context.translate(0.5, 0.5);
+
+    return { width, height, context };
+  }
+
+  componentDidUpdate() {
+    this.props.onSizeChange();
+  }
+
+  componentDidMount() {
+    this._setSizeFromWrapper();
+    this.__setSizeInterval = setInterval(this._setSizeFromWrapper.bind(this), 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.__setSizeInterval);
+  }
+
+  private _setSizeFromWrapper() {
+    const wrapper = this.refs['wrapper'] as HTMLElement;
+    this.setState({
+      width: wrapper.offsetWidth,
+      height: wrapper.offsetHeight
+    });
+  }
+}

--- a/src/core/layers/PollingResizingCanvasLayer.tsx
+++ b/src/core/layers/PollingResizingCanvasLayer.tsx
@@ -17,6 +17,7 @@ export default class PollingResizingCanvasLayer extends React.Component<Props, S
 
   static propTypes = {
     onSizeChange: React.PropTypes.func.isRequired,
+    pixelRatio: React.PropTypes.number
   } as React.ValidationMap<Props>;
 
   static defaultProps = {

--- a/src/core/layers/SimpleLineLayer.tsx
+++ b/src/core/layers/SimpleLineLayer.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import { getIndexBoundsForPointData } from '../renderUtils';
 import { wrapWithAnimatedYDomain } from '../componentUtils';
 import propTypes from '../propTypes';
@@ -40,14 +40,15 @@ class SimpleLineLayer extends React.Component<Props, void> {
   } as any as Props;
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     // Should we draw something if there is one data point?
     if (this.props.data.length < 2) {

--- a/src/core/layers/SpanLayer.tsx
+++ b/src/core/layers/SpanLayer.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import { getIndexBoundsForSpanData } from '../renderUtils';
 import propTypes from '../propTypes';
 import { Interval, Color } from '../interfaces';
@@ -42,14 +42,15 @@ export default class SpanLayer extends React.Component<Props, void> {
   };
 
   render() {
-    return <AutoresizingCanvasLayer ref='canvasLayer' onSizeChange={this.nonReactRender}/>;
+    return <PollingResizingCanvasLayer
+      ref='canvasLayer'
+      onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
+    />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     const { firstIndex, lastIndex } = getIndexBoundsForSpanData(this.props.data, this.props.xDomain, 'minXValue', 'maxXValue');
     if (firstIndex === lastIndex) {

--- a/src/core/layers/XAxisLayer.tsx
+++ b/src/core/layers/XAxisLayer.tsx
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
 import NonReactRender from '../decorators/NonReactRender';
 import PixelRatioContext, { Context } from '../decorators/PixelRatioContext';
 
-import AutoresizingCanvasLayer from './AutoresizingCanvasLayer';
+import PollingResizingCanvasLayer from './PollingResizingCanvasLayer';
 import propTypes from '../propTypes';
 import { computeTicks } from '../renderUtils';
 import { Interval, ScaleFunction, Ticks, TickFormat, Color, AxisSpec } from '../interfaces';
@@ -39,18 +39,15 @@ export default class XAxisLayer extends React.Component<Props, void> {
   };
 
   render() {
-    return <AutoresizingCanvasLayer
-      className='x-axis'
+    return <PollingResizingCanvasLayer
       ref='canvasLayer'
       onSizeChange={this.nonReactRender}
+      pixelRatio={this.context.pixelRatio}
     />;
   }
 
   nonReactRender = () => {
-    const { width, height, context } = AutoresizingCanvasLayer.resetCanvas(
-      this.refs['canvasLayer'] as AutoresizingCanvasLayer,
-      this.context.pixelRatio
-    );
+    const { width, height, context } = (this.refs['canvasLayer'] as PollingResizingCanvasLayer).resetCanvas();
 
     const xScale = this.props.scale()
       .domain([ this.props.xDomain.min, this.props.xDomain.max ])

--- a/src/core/layers/index.ts
+++ b/src/core/layers/index.ts
@@ -4,6 +4,11 @@ export {
 } from './AutoresizingCanvasLayer';
 
 export {
+  default as PollingResizingCanvasLayer,
+  Props as PollingResizingCanvasLayerProps
+} from './PollingResizingCanvasLayer';
+
+export {
   default as BarLayer,
   Props as BarLayerProps
 } from './BarLayer';


### PR DESCRIPTION
This fixes an API loophole where you had to make sure `AutoresizingCanvasLayer#resetCanvas` received the same value for pixel ratio that it received from context. This is redundant and therefore could be easily forgotten. `PollingResizingCanvasLayer` changes this to be a single point of truth, while also simplifying the API (making the needlessly-static method an instance method and removing the useless `className` support).