### PR TITLE
Don't set Y domains from dataLoader's results.

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,7 +34,7 @@ For specifics on the exact types of these components/functions/values, please ch
 
 #### Controlled Props
 
-These props come in read-write pairs and implement the ["controlled component" pattern](https://facebook.github.io/react/docs/forms.html#controlled-components). The "value" props unconditionally trump any automatically-computed values. The "on change" props are called any time the automatically-computed values change to give the parent a chance to incorporate those changes. You can provide any combination of these parameters; providing a "value" prop doesn't imply you need an "on change" prop, nor vice versa.
+These props come in read-write pairs and implement the ["controlled component" pattern](https://facebook.github.io/react/docs/forms.html#controlled-components). The "value" props unconditionally trump any automatically-computed values or values set with action creators. The "on change" props are called any time the automatically-computed values change to give the parent a chance to incorporate those changes. You can provide any combination of these parameters; providing a "value" prop doesn't imply you need an "on change" prop, nor vice versa.
 
 - `xDomain?`
 - `onXDomainChange?()`
@@ -277,7 +277,7 @@ export default connect(mapStateToProps)(ExampleComponent);
 
 ### Action Creators
 
-These action creators are analogous to some of the "controlled props" on `ChartProvider`. They are intended to be used with [`connect`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) and, optionally, [`bindActionCreators`](http://redux.js.org/docs/api/bindActionCreators.html).
+These action creators are analogous to some of the "controlled props" on `ChartProvider`. They are intended to be used with [`connect`](https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options) and, optionally, [`bindActionCreators`](http://redux.js.org/docs/api/bindActionCreators.html). Values set with action creators are preferred over automatically-computed values or defaults, but `ChartProvider`'s controlled props are preferred over all.
 
 - `setXDomain(domain)`
 - `setYDomains(domains)`
@@ -373,7 +373,9 @@ class ExampleParentComponent extends React.Component<Props, ...> { ... }
 
 ### Functions
 
-#### `createStaticDataLoader(data, yDomains)`
+#### ~~`createStaticDataLoader(data, yDomains)`~~
+
+**This function is deprecated. Create a `Promise` and return that from a function instead.**
 
 Create a loader appropriate to pass to `ChartProvider` that unconditionally returns the provided static data. Useful for making simple interactive charts that have static data.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-### Unreleased
+## Unreleased
 
 ### Added
 
@@ -11,10 +11,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Deprecated
 
 - `XAxisLayer` and `YAxisLayer` in favor of `XAxis` and `YAxis`. [#72](https://github.com/palantir/react-layered-chart/issues/72).
+- `loadData`'s 3rd (`currentYDomains`) and 5th (`currentData`) arguments are deprecated in favor of the new 6th argument (`currentLoadedData`). [#77](https://github.com/palantir/react-layered-chart/pull/77).
+- `createStaticDataLoader` is deprecated in favor of creating a `Promise` and returning your data from that. [#77](https://github.com/palantir/react-layered-chart/issues/79).
 
 ### Changed
 
 - Expanded the legal arguments to `computeTicks`. [#23](https://github.com/palantir/react-layered-chart/pull/23).
+- Added an extra argument to `loadData` for the currently-loaded data. [#77](https://github.com/palantir/react-layered-chart/issues/77).
+- The data-loading pipeline no longer uses `setYDomains`, thus avoiding mixed signals when custom components try to use `setYDomains` also. `setYDomains` now always takes precendence over the values returned from `loadData`. [#77](https://github.com/palantir/react-layered-chart/issues/77).
+- `ChartProvider`'s `yDomains` prop and `setYDomains` no longer need to include an entry for every series. Whatever subset they provide will be merged with any appropriate defaults. [#78](https://github.com/palantir/react-layered-chart/issues/78).
+
 
 ## 1.4.1 (2016-09-13)
 

--- a/src/connected/ChartProvider.tsx
+++ b/src/connected/ChartProvider.tsx
@@ -137,36 +137,31 @@ export default class ChartProvider extends React.Component<Props, {}> {
 
   private _maybeFireAllCallbacks() {
     const state: ChartState = this._store.getState();
-    this._maybeFireCallback(state.uiState.xDomain,           this._lastState.uiState.xDomain,           this.props.onXDomainChange);
-    this._maybeFireCallback(state.uiState.yDomainBySeriesId, this._lastState.uiState.yDomainBySeriesId, this.props.onYDomainsChange);
-    this._maybeFireCallback(state.uiState.selection,         this._lastState.uiState.selection,         this.props.onSelectionChange);
-    this._maybeFireCallback(state.uiState.hover,             this._lastState.uiState.hover,             this.props.onHoverChange);
+    this._maybeFireCallback(state.uiState.xDomain,   this._lastState.uiState.xDomain,   this.props.onXDomainChange);
+    this._maybeFireCallback(state.uiState.selection, this._lastState.uiState.selection, this.props.onSelectionChange);
+    this._maybeFireCallback(state.uiState.hover,     this._lastState.uiState.hover,     this.props.onHoverChange);
+    this._maybeFireCallback(state.errorBySeriesId,   this._lastState.errorBySeriesId,   this.props.onError);
 
-    // TODO: These two should maybe be replaced with delegations to selectors.
-    this._maybeFireCallback(state.errorBySeriesId, this._lastState.errorBySeriesId, this.props.onError);
-    this._maybeFireCallbackWithConversion(
-      state.loadVersionBySeriesId,
-      this._lastState.loadVersionBySeriesId,
-      (loadVersions) => _.mapValues(loadVersions, v => !!v),
-      this.props.onLoadStateChange
-    );
+    if (this.props.onLoadStateChange) {
+      if (state.loadVersionBySeriesId !== this._lastState.loadVersionBySeriesId) {
+        this.props.onLoadStateChange(_.mapValues(state.loadVersionBySeriesId, v => !!v));
+      }
+    }
+
+    if (this.props.onYDomainsChange) {
+      if (state.uiState.yDomainBySeriesId !== this._lastState.uiState.yDomainBySeriesId || state.loadedDataBySeriesId !== this._lastState.loadedDataBySeriesId) {
+        const internalYDomains = _.assign({}, state.uiState.yDomainBySeriesId, _.mapValues(state.loadedDataBySeriesId, loadedData => loadedData.yDomain));
+        this.props.onYDomainsChange(internalYDomains);
+      }
+    }
+
+
     this._lastState = state;
   }
 
   private _maybeFireCallback<T>(currentState: T, lastState: T, callback?: (value: T) => void) {
     if (callback && currentState !== lastState) {
       callback(currentState);
-    }
-  }
-
-  private _maybeFireCallbackWithConversion<T, U>(
-    currentState: T,
-    lastState: T,
-    conversion: (value: T) => U,
-    callback?: (value: U) => void
-  ) {
-    if (callback && currentState !== lastState) {
-      callback(conversion(currentState));
     }
   }
 

--- a/src/connected/export-only/exportableSelectors.ts
+++ b/src/connected/export-only/exportableSelectors.ts
@@ -48,7 +48,7 @@ export function createSelectDataForHover(xValueSelector: NumericalValueIterator)
           return datum.hasOwnProperty('__haxWrappedHover')
             ? datum.__haxWrappedHover
             : xValueSelector(seriesId, datum);
-        }
+        };
 
         return _.mapValues(dataBySeriesId, (data: any[], seriesId: SeriesId) => {
           // -1 because sortedIndexBy returns the first index that would be /after/ the input value, but we're trying to

--- a/src/connected/flux/atomicActions.ts
+++ b/src/connected/flux/atomicActions.ts
@@ -1,4 +1,4 @@
-import { Interval, SeriesData } from '../../core/interfaces';
+import { Interval } from '../../core/interfaces';
 import { SeriesId, TBySeriesId, DataLoader, LoadedSeriesData } from '../interfaces';
 
 export enum ActionType {
@@ -45,5 +45,5 @@ export const setSelection = createActionCreator<Interval>(ActionType.SET_SELECTI
 export const setOverrideSelection = createActionCreator<Interval>(ActionType.SET_OVERRIDE_SELECTION);
 
 export const dataRequested = createActionCreator<SeriesId[]>(ActionType.DATA_REQUESTED);
-export const dataReturned = createActionCreator<TBySeriesId<SeriesData>>(ActionType.DATA_RETURNED);
+export const dataReturned = createActionCreator<TBySeriesId<LoadedSeriesData>>(ActionType.DATA_RETURNED);
 export const dataErrored = createActionCreator<TBySeriesId<any>>(ActionType.DATA_ERRORED);

--- a/src/connected/flux/reducer.ts
+++ b/src/connected/flux/reducer.ts
@@ -23,12 +23,9 @@ export default function(state: ChartState, action: Action<any>): ChartState {
       const seriesIds = action.payload;
       return update(state, {
         seriesIds: { $set: seriesIds },
-        dataBySeriesId: { $set: objectWithKeysFromObject(state.dataBySeriesId, seriesIds, []) },
+        loadedDataBySeriesId: { $set: objectWithKeysFromObject(state.loadedDataBySeriesId, seriesIds, { data: [], yDomain: DEFAULT_Y_DOMAIN }) },
         loadVersionBySeriesId: { $set: objectWithKeysFromObject(state.loadVersionBySeriesId, seriesIds, null) },
-        errorBySeriesId: { $set: objectWithKeysFromObject(state.errorBySeriesId, seriesIds, null) },
-        uiState: {
-          yDomainBySeriesId: { $set: objectWithKeysFromObject(state.uiState.yDomainBySeriesId, seriesIds, DEFAULT_Y_DOMAIN) }
-        }
+        errorBySeriesId: { $set: objectWithKeysFromObject(state.errorBySeriesId, seriesIds, null) }
       });
     }
 
@@ -39,7 +36,7 @@ export default function(state: ChartState, action: Action<any>): ChartState {
 
     case ActionType.DATA_RETURNED:
       return update(state, {
-        dataBySeriesId: { $assign: action.payload },
+        loadedDataBySeriesId: { $assign: action.payload },
         loadVersionBySeriesId: { $assign: replaceValuesWithConstant(action.payload, null) },
         errorBySeriesId: { $assign: replaceValuesWithConstant(action.payload, null) }
       });

--- a/src/connected/interfaces.ts
+++ b/src/connected/interfaces.ts
@@ -13,4 +13,5 @@ export type DataLoader = (seriesIds: SeriesId[],
                           xDomain: Interval,
                           currentYDomains: TBySeriesId<Interval>,
                           chartPixelWidth: number,
-                          currentData: TBySeriesId<SeriesData>) => TBySeriesId<Promise<LoadedSeriesData>>;
+                          currentData: TBySeriesId<SeriesData>,
+                          currentLoadedData: TBySeriesId<LoadedSeriesData>) => TBySeriesId<Promise<LoadedSeriesData>>;

--- a/src/connected/model/selectors.ts
+++ b/src/connected/model/selectors.ts
@@ -5,15 +5,26 @@ import { Interval } from '../../core';
 import { TBySeriesId } from '../interfaces';
 import { ChartState, UiState } from './state';
 
-const selectUiStateInternal = (state: ChartState) => state.uiState;
-const selectUiStateOverride = (state: ChartState) => state.uiStateConsumerOverrides;
-
 function createUiStateSelector<T>(selectUiState: (state: ChartState) => UiState, fieldName: string): (state: ChartState) => T {
   return createSelector(
     selectUiState,
     (uiState: UiState) => uiState[fieldName]
   );
 }
+
+const selectLoadedSeriesData = (state: ChartState) => state.loadedDataBySeriesId;
+const selectUiStateInternal = (state: ChartState) => state.uiState;
+const selectUiStateOverride = (state: ChartState) => state.uiStateConsumerOverrides;
+
+export const selectLoadedYDomains = createSelector(
+  selectLoadedSeriesData,
+  (loadedSeriesData) => _.mapValues(loadedSeriesData, loadedSeriesData => loadedSeriesData.yDomain)
+);
+
+export const selectData = createSelector(
+  selectLoadedSeriesData,
+  (loadedSeriesData) => _.mapValues(loadedSeriesData, loadedSeriesData => loadedSeriesData.data)
+);
 
 export const selectXDomain = createSelector(
   createUiStateSelector<Interval>(selectUiStateInternal, 'xDomain'),
@@ -22,9 +33,10 @@ export const selectXDomain = createSelector(
 );
 
 export const selectYDomains = createSelector(
+  selectLoadedYDomains,
   createUiStateSelector<TBySeriesId<Interval>>(selectUiStateInternal, 'yDomainBySeriesId'),
   createUiStateSelector<TBySeriesId<Interval>>(selectUiStateOverride, 'yDomainBySeriesId'),
-  (internal: TBySeriesId<Interval>, override: TBySeriesId<Interval>) => override || internal
+  (loaded, internal, override) => _.assign({}, loaded, internal, override) as TBySeriesId<Interval>
 );
 
 export const selectHover = createSelector(
@@ -39,4 +51,3 @@ export const selectSelection = createSelector(
   (internal: Interval, override: Interval) => override || internal
 );
 
-export const selectData = (state: ChartState) => state.dataBySeriesId;

--- a/src/connected/model/state.ts
+++ b/src/connected/model/state.ts
@@ -1,4 +1,4 @@
-import { Interval, SeriesData } from '../../core';
+import { Interval } from '../../core';
 
 import { DEFAULT_X_DOMAIN } from './constants';
 import { SeriesId, TBySeriesId, DataLoader, LoadedSeriesData } from '../interfaces';
@@ -19,7 +19,7 @@ export interface ChartState {
   debounceTimeout: number;
   physicalChartWidth: number;
   seriesIds: SeriesId[];
-  dataBySeriesId: TBySeriesId<SeriesData>;
+  loadedDataBySeriesId: TBySeriesId<LoadedSeriesData>;
   loadVersionBySeriesId: TBySeriesId<string>;
   errorBySeriesId: TBySeriesId<any>;
   dataLoader: DataLoader;
@@ -35,7 +35,7 @@ export const DEFAULT_CHART_STATE: ChartState = {
   debounceTimeout: 1000,
   physicalChartWidth: 200,
   seriesIds: [],
-  dataBySeriesId: {},
+  loadedDataBySeriesId: {},
   loadVersionBySeriesId: {},
   errorBySeriesId: {},
   dataLoader: invalidLoader,

--- a/test/selectors-test.ts
+++ b/test/selectors-test.ts
@@ -3,7 +3,9 @@ import {
   selectXDomain,
   selectYDomains,
   selectHover,
-  selectSelection
+  selectSelection,
+  selectLoadedYDomains,
+  selectData
 } from '../src/connected/model/selectors';
 import {
   selectIsLoading,
@@ -13,8 +15,11 @@ import {
 describe('(selectors)', () => {
   const SERIES_A = 'a';
   const SERIES_B = 'b';
+  const SERIES_C = 'c';
   const INTERVAL_A: Interval = { min: 0, max: 1 };
   const INTERVAL_B: Interval = { min: 2, max: 3 };
+  const INTERVAL_C: Interval = { min: 4, max: 5 };
+  const DATA_A = [{ a: true }];
 
   describe('selectXDomain', () => {
     it('should use the internal value if no override is set', () => {
@@ -39,8 +44,29 @@ describe('(selectors)', () => {
   });
 
   describe('selectYDomains', () => {
-    it('should use the internal value if no override is set', () => {
+    it('should use the loaded value if no action-set value or override are set', () => {
       selectYDomains({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_A
+          }
+        },
+        uiState: {},
+        uiStateConsumerOverrides: {}
+      } as any).should.deepEqual({
+        [SERIES_A]: INTERVAL_A
+      });
+    });
+
+    it('should use the action-set value if no override is set', () => {
+      selectYDomains({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_B
+          }
+        },
         uiState: {
           yDomainBySeriesId: {
             [SERIES_A]: INTERVAL_A
@@ -52,20 +78,75 @@ describe('(selectors)', () => {
       });
     });
 
-    it('should use the override if set', () => {
+    it('should use the override if all three values are set', () => {
       selectYDomains({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_B
+          }
+        },
         uiState: {
           yDomainBySeriesId: {
-            [SERIES_A]: INTERVAL_A
+            [SERIES_A]: INTERVAL_B
           }
         },
         uiStateConsumerOverrides: {
           yDomainBySeriesId: {
-            [SERIES_B]: INTERVAL_B
+            [SERIES_A]: INTERVAL_A
           }
         }
       } as any).should.deepEqual({
-        [SERIES_B]: INTERVAL_B
+        [SERIES_A]: INTERVAL_A
+      });
+    });
+
+    it('should use the override if set', () => {
+      selectYDomains({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_B
+          }
+        },
+        uiState: {},
+        uiStateConsumerOverrides: {
+          yDomainBySeriesId: {
+            [SERIES_A]: INTERVAL_A
+          }
+        }
+      } as any).should.deepEqual({
+        [SERIES_A]: INTERVAL_A
+      });
+    });
+
+    it('should merge subets of domains from different settings, preferring override, then action-set, then loaded', () => {
+      selectYDomains({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_A
+          },
+          [SERIES_B]: {
+            data: [],
+            yDomain: INTERVAL_A
+          }
+        },
+        uiState: {
+          yDomainBySeriesId: {
+            [SERIES_B]: INTERVAL_B,
+            [SERIES_C]: INTERVAL_B
+          }
+        },
+        uiStateConsumerOverrides: {
+          yDomainBySeriesId: {
+            [SERIES_C]: INTERVAL_C
+          }
+        }
+      } as any).should.deepEqual({
+        [SERIES_A]: INTERVAL_A,
+        [SERIES_B]: INTERVAL_B,
+        [SERIES_C]: INTERVAL_C
       });
     });
   });
@@ -125,6 +206,46 @@ describe('(selectors)', () => {
     });
   });
 
+  describe('selectLoadedYDomains', () => {
+    it('should select only the loaded Y domains even if action-set values and overrides are set', () => {
+      selectLoadedYDomains({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_A
+          }
+        },
+        uiState: {
+          yDomainBySeriesId: {
+            [SERIES_A]: INTERVAL_B
+          }
+        },
+        uiStateConsumerOverrides: {
+          yDomainBySeriesId: {
+            [SERIES_A]: INTERVAL_B
+          }
+        }
+      } as any).should.deepEqual({
+        [SERIES_A]: INTERVAL_A
+      });
+    });
+  });
+
+  describe('selectData', () => {
+    it('should select only the data arrays', () => {
+      selectData({
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: DATA_A,
+            yDomain: INTERVAL_A
+          }
+        }
+      } as any).should.deepEqual({
+        [SERIES_A]: DATA_A
+      });
+    });
+  });
+
   describe('selectIsLoading', () => {
     it('should convert the raw map to be a map to booleans', () => {
       selectIsLoading({
@@ -149,8 +270,11 @@ describe('(selectors)', () => {
 
     it('should return undefineds if hover is unset', () => {
       selectDataForHover({
-        dataBySeriesId: {
-          [SERIES_A]: [{ x: 0}]
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [{ x: 0}],
+            yDomain: INTERVAL_A
+          }
         },
         uiState: {
           hover: null
@@ -163,8 +287,11 @@ describe('(selectors)', () => {
 
     it('should return undefineds for empty series', () => {
       selectDataForHover({
-        dataBySeriesId: {
-          [SERIES_A]: []
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: [],
+            yDomain: INTERVAL_A
+          }
         },
         uiState: {
           hover: 10
@@ -177,8 +304,11 @@ describe('(selectors)', () => {
 
     it('should return the datum immediately preceding the hover value', () => {
       selectDataForHover({
-        dataBySeriesId: {
-          [SERIES_A]: DATA
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: DATA,
+            yDomain: INTERVAL_A
+          }
         },
         uiState: {
           hover: 10
@@ -189,8 +319,11 @@ describe('(selectors)', () => {
 
     it('should return undefined for series whose earilest datum is after the hover', () => {
       selectDataForHover({
-        dataBySeriesId: {
-          [SERIES_A]: DATA
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: DATA,
+            yDomain: INTERVAL_A
+          }
         },
         uiState: {
           hover: 0
@@ -203,8 +336,11 @@ describe('(selectors)', () => {
 
     it('should return the datum immediately preceding the hover value when hover is overridden', () => {
       selectDataForHover({
-        dataBySeriesId: {
-          [SERIES_A]: DATA
+        loadedDataBySeriesId: {
+          [SERIES_A]: {
+            data: DATA,
+            yDomain: INTERVAL_A
+          }
         },
         uiState: {
           hover: null


### PR DESCRIPTION
Fixes #77, #78.