### PR TITLE
Fix ChartProvider to respect a value of `0` for `hover`.

### DIFF
--- a/src/connected/ChartProvider.tsx
+++ b/src/connected/ChartProvider.tsx
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import * as React from 'react';
 import * as PureRender from 'pure-render-decorator';
 import * as classNames from 'classnames';
@@ -131,7 +132,7 @@ export default class ChartProvider extends React.Component<Props, {}> {
     } else if (props.defaultState && props.defaultState.yDomains) {
       this._store.dispatch(setYDomains(props.defaultState.yDomains));
     }
-    if (props.hover) {
+    if (_.isNumber(props.hover)) {
       this._store.dispatch(setOverrideHover(props.hover));
     }
     if (props.selection) {


### PR DESCRIPTION
Additionally, include a missing import for `lodash`.