### PR TITLE
Allow controlling hover and selection as 'none'

### DIFF
--- a/src/connected/ChartProvider.tsx
+++ b/src/connected/ChartProvider.tsx
@@ -45,9 +45,9 @@ export interface Props {
   onXDomainChange?: (xDomain: Interval) => void;
   yDomains?: TBySeriesId<Interval>;
   onYDomainsChange?: (yDomains: TBySeriesId<Interval>) => void;
-  selection?: Interval;
+  selection?: Interval | 'none';
   onSelectionChange?: (selection: Interval) => void;
-  hover?: number;
+  hover?: number | 'none';
   onHoverChange?: (hover: number) => void;
 }
 
@@ -132,7 +132,7 @@ export default class ChartProvider extends React.Component<Props, void> {
     } else if (props.defaultState && props.defaultState.yDomains) {
       this._store.dispatch(setYDomains(props.defaultState.yDomains));
     }
-    if (_.isNumber(props.hover)) {
+    if (props.hover != null) {
       this._store.dispatch(setOverrideHover(props.hover));
     }
     if (props.selection) {

--- a/src/connected/flux/atomicActions.ts
+++ b/src/connected/flux/atomicActions.ts
@@ -42,9 +42,9 @@ export const setOverrideXDomain = createActionCreator<Interval>(ActionType.SET_O
 export const setYDomains = createActionCreator<TBySeriesId<Interval>>(ActionType.SET_Y_DOMAINS);
 export const setOverrideYDomains = createActionCreator<TBySeriesId<Interval>>(ActionType.SET_OVERRIDE_Y_DOMAINS);
 export const setHover = createActionCreator<number>(ActionType.SET_HOVER);
-export const setOverrideHover = createActionCreator<number>(ActionType.SET_OVERRIDE_HOVER);
+export const setOverrideHover = createActionCreator<number | 'none'>(ActionType.SET_OVERRIDE_HOVER);
 export const setSelection = createActionCreator<Interval>(ActionType.SET_SELECTION);
-export const setOverrideSelection = createActionCreator<Interval>(ActionType.SET_OVERRIDE_SELECTION);
+export const setOverrideSelection = createActionCreator<Interval | 'none'>(ActionType.SET_OVERRIDE_SELECTION);
 
 export const dataRequested = createActionCreator<SeriesId[]>(ActionType.DATA_REQUESTED);
 export const dataReturned = createActionCreator<TBySeriesId<LoadedSeriesData>>(ActionType.DATA_RETURNED);

--- a/src/connected/flux/reducer.ts
+++ b/src/connected/flux/reducer.ts
@@ -122,7 +122,7 @@ export default function(state: ChartState, action: Action<any>): ChartState {
       });
 
     case ActionType.SET_OVERRIDE_HOVER:
-      if (_.isNumber(action.payload)) {
+      if (action.payload != null) {
         return update(state, {
           uiStateConsumerOverrides: {
             hover: { $set: action.payload }

--- a/src/connected/model/state.ts
+++ b/src/connected/model/state.ts
@@ -15,6 +15,13 @@ export interface UiState {
   selection?: Interval;
 }
 
+export interface OverriddenUiState {
+  xDomain?: Interval;
+  yDomainBySeriesId?: TBySeriesId<Interval>;
+  hover?: number | 'none';
+  selection?: Interval | 'none';
+}
+
 export interface ChartState {
   debounceTimeout: number;
   loaderContext?: any;
@@ -25,7 +32,7 @@ export interface ChartState {
   errorBySeriesId: TBySeriesId<any>;
   dataLoader: DataLoader;
   uiState: UiState;
-  uiStateConsumerOverrides: UiState;
+  uiStateConsumerOverrides: OverriddenUiState;
 }
 
 export const invalidLoader = (() => {

--- a/test/selectors-test.ts
+++ b/test/selectors-test.ts
@@ -184,6 +184,17 @@ describe('(selectors)', () => {
         }
       } as any)).to.equal(0);
     });
+
+    it('should not exist when the override is set to \'none\'', () => {
+      expect(selectHover({
+        uiState: {
+          hover: 5
+        },
+        uiStateConsumerOverrides: {
+          hover: 'none'
+        }
+      } as any)).to.not.exist;
+    });
   });
 
   describe('selectSelection', () => {
@@ -205,6 +216,17 @@ describe('(selectors)', () => {
           selection: INTERVAL_B
         }
       } as any)).to.equal(INTERVAL_B);
+    });
+
+    it('should not exist when the override is set to \'none\'', () => {
+      expect(selectHover({
+        uiState: {
+          selection: INTERVAL_A
+        },
+        uiStateConsumerOverrides: {
+          selection: 'none'
+        }
+      } as any)).to.not.exist;
     });
   });
 


### PR DESCRIPTION
This is still a bit of a booby-trapped API because I think
it'll be easy to forget to convert undefined into 'none'
when passing it to ChartProvider as a consumer; but that's
a pretty small surface area, and at least it works.